### PR TITLE
Create Mobx example

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Render(globalState, <Counter/>)
 
 [Live Example on WebpackBin](http://www.webpackbin.com/4JkiMmkKM)
 
+```
 # Mobx
 
 const store = new class CounterStore {
@@ -294,5 +295,6 @@ const Counter = observer((props) => {
     </div>
   );
 });
+```
 
 [Live Example on JSBin](http://jsbin.com/tenudazego/edit?js,output)

--- a/README.md
+++ b/README.md
@@ -295,4 +295,4 @@ const Counter = observer((props) => {
   );
 });
 
-// Live Example waiting on getting decorators working in webpackbin...
+[Live Example on JSBin](http://jsbin.com/tenudazego/edit?js,output)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ _No counters were harmed in the making of these examples._
 - [Elm](#elm)
 - [Cycle.js](#cyclejs)
 - [Jumpsuit](#jumpsuit)
+- [Mobx](#mobx)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -275,3 +276,23 @@ Render(globalState, <Counter/>)
 ```
 
 [Live Example on WebpackBin](http://www.webpackbin.com/4JkiMmkKM)
+
+# Mobx
+
+const store = new class CounterStore {
+  @observable count = 0;
+  @action increment = () => this.count++
+  @action decrement = () => this.count-- 
+}
+
+const Counter = observer((props) => {
+  return (
+    <div>
+      <h1>{store.count}</h1>
+      <button onClick={store.increment}>Increment</button>
+      <button onClick={store.decrement}>Decrement</button>
+    </div>
+  );
+});
+
+// Live Example waiting on getting decorators working in webpackbin...


### PR DESCRIPTION
There are a few different ways to handle state in mobx. I suppose this is just one (opinionated) idea. 

in this case I am : 
- using es7 decorators (which seems problematic with webpackbin, so I might just have to go the es6 way and rewrite the example...
- since the store + component are in the same code example, I just used the store variable rather than passing it as a prop through a `<Provider>` .

I'm going to keep trying to get an example working in an webpackbin / jsbin... if you have any tips let me know. Just thought I'd make this PR in the meantime. Feel free to close / pend until more results.