### PR TITLE
Add package.json for declaring doctoc and other bits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Rx.Observable.merge(inc$, dec$)
 
 # React
 
-```js
+```jsx
 class Counter extends React.Component {
   state = {count: 0}
 
@@ -121,7 +121,7 @@ class Counter extends React.Component {
   decrement = e =>
     this.setState({ count: this.state.count - 1 })
 
-  render = () =>  
+  render = () =>
     <div>
       <h1>{this.state.count}</h1>
       <button onClick={this.increment}>Increment</button>
@@ -134,7 +134,7 @@ class Counter extends React.Component {
 
 # React + Redux
 
-```js
+```jsx
 import { createStore } from 'redux'
 
 const reducer = (state = 0, action) => {
@@ -152,7 +152,7 @@ var Counter = ({ count, onIncrement, onDecrement }) => (
     <h1>{count}</h1>
     <button onClick={onIncrement}>Increment</button>
     <button onClick={onDecrement}>Decrement</button>
-  </div>  
+  </div>
 )
 
 const render = () => {
@@ -235,7 +235,7 @@ export class CounterComponent {
 
 # Hyperapp
 
-```js
+```jsx
 app({
   model: 0,
   update: {
@@ -255,15 +255,14 @@ app({
 
 # Vue.js
 
+```html
+<div id="app">
+  <h1>{{ count }}</h1>
+  <button v-on:click="increment">Increment</button>
+  <button v-on:click="decrement">Decrement</button>
+</div>
+```
 ```js
-// html
-// ----
-// <div id="app">
-//   <h1>{{ count }}</h1>
-//   <button v-on:click="increment">Increment</button>
-//   <button v-on:click="decrement">Decrement</button>
-// </div>
-
 new Vue({
   el: '#app',
   data: { count: 0 },
@@ -363,7 +362,7 @@ Render(globalState, <Counter/>)
 
 # Mobx
 
-```js
+```jsx
 const store = new class CounterStore {
   @observable count = 0
   @action increment = () => this.count++

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "doctoc": "doctoc"
+  },
+  "devDependencies": {
+    "doctoc": "^1.2.0"
+  }
+}


### PR DESCRIPTION
* This makes it easier for contributors to follow the contribution guidelines. Users don't need to install doctoc globally to use it now.

* Also, use ```jsx for code blocks using JSX. 
```js
const view = 
  <div>
    <button 
      onclick={e => console.log(e)}>Click Me!
    </button>
  </div>
```
VS
```jsx
const view = 
  <div>
    <button 
      onclick={e => console.log(e)}>Click Me!
    </button>
  </div>
```